### PR TITLE
docs: README freshness update — fix dead Full Stack Deep Learning link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,7 +1024,7 @@ notice when they are wrong.
   monitoring, and iteration. **Free**
 - [Machine Learning Zoomcamp](https://github.com/DataTalksClub/machine-learning-zoomcamp) -
   practical ML engineering and deployment. **Free**
-- [Full Stack Deep Learning](https://fullstackdeeplearning.com/) - ML product
+- [Full Stack Deep Learning](https://github.com/the-full-stack/the-full-stack-website) - ML product
   engineering and deployment. **Free materials**
 - [Hugging Face Agents Course](https://huggingface.co/learn/agents-course) -
   agent concepts and hands-on projects when publicly available. **Free**


### PR DESCRIPTION
## What changed

The [fullstackdeeplearning.com](https://fullstackdeeplearning.com/) domain is no longer reachable (DNS failure — confirmed via multiple checks). This was the only genuinely broken link found during a full audit of this README.

### Fix
- Updated the Full Stack Deep Learning link to point to their [GitHub repository](https://github.com/the-full-stack/the-full-stack-website) instead of the dead domain.

### Note on other 403 results
Several other URLs (leetcode.com, realpython.com, runestone.academy, etc.) return 403 to automated link checkers due to bot protection, but load fine in real browsers. These are not broken and were intentionally left as-is.

---
*Generated by automated README freshness audit*